### PR TITLE
Meta: 絶対に LF を強制する

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,1 +1,1 @@
-text eol=lf
+* text=auto

--- a/.gitattribute
+++ b/.gitattribute
@@ -1,0 +1,1 @@
+text eol=lf


### PR DESCRIPTION
Windows ユーザのファイルと macOS ユーザのファイルが混在しており、改行コードがとんでもないことになっているため、LF を強制する