### PR TITLE
ポスター掲示場所の表示を修正しました

### DIFF
--- a/src/pages/PosterList.jsx
+++ b/src/pages/PosterList.jsx
@@ -6,25 +6,57 @@ export const PosterList = () => {
             <h2 className="section-title">ポスター掲示場所</h2>
             <div className="pos-list">
                 <div className="heading">高校</div>
-                安古市高等学校 安芸府中高等学校 安芸南高等学校 井口高等学校
-                海田高等学校 賀茂高等学校 広島工業大学高等学校
-                広島国際学院高等学校 広島国泰寺高校 崇徳高等学校
-                広島県瀬戸内高等学校 廿日市高等学校 比治山女子高等学校
-                山陽高等学校 広島城北高等学校 安田女子高等学校 広高等学校
-                舟入高等学校 美鈴が丘高等学校 皆実高等学校 沼田高等学校
-                基町高等学校
+                <nobr>安古市高等学校</nobr>
+                <nobr>安芸府中高等学校</nobr>
+                <nobr>安芸南高等学校</nobr>
+                <nobr>井口高等学校</nobr>
+                <nobr>海田高等学校</nobr>
+                <nobr>賀茂高等学校</nobr>
+                <nobr>広島工業大学高等学校</nobr>
+                <nobr>広島国際学院高等学校</nobr>
+                <nobr>広島国泰寺高校</nobr>
+                <nobr>崇徳高等学校</nobr>
+                <nobr>広島県瀬戸内高等学校</nobr>
+                <nobr>廿日市高等学校</nobr>
+                <nobr>比治山女子高等学校</nobr>
+                <nobr>山陽高等学校</nobr>
+                <nobr>広島城北高等学校</nobr>
+                <nobr>安田女子高等学校</nobr>
+                <nobr>広高等学校</nobr>
+                <nobr>舟入高等学校</nobr>
+                <nobr>美鈴が丘高等学校</nobr>
+                <nobr>皆実高等学校</nobr>
+                <nobr>沼田高等学校</nobr>
+                <nobr>基町高等学校</nobr>
                 <div className="heading">大学</div>
-                広島修道大学 広島工業大学 広島工業大学 大学院 広島都市学園大学
-                宇品キャンパス 広島都市学園大学 西風新都キャンパス 広島経済大学
+                <nobr>広島修道大学</nobr>
+                <nobr>広島工業大学</nobr>
+                <nobr>広島工業大学大学院</nobr>
+                <nobr>広島都市学園大学宇品キャンパス</nobr>
+                <nobr>広島都市学園大学西風新都キャンパス</nobr>
+                <nobr>広島経済大学</nobr>
                 <div className="heading">公共交通機関</div>
-                JR横川駅 広電バス アストラムライン 大塚駅 アストラムライン
-                広域公園前駅 アストラムライン 伴中央駅 市区役所公民館 中区役所
-                西区役所 安佐南区役所 佐伯区役所
+                <nobr>JR横川駅</nobr>
+                <nobr>広電バス</nobr>
+                <nobr>アストラムライン大塚駅</nobr>
+                <nobr>アストラムライン広域公園前駅</nobr>
+                <nobr>アストラムライン伴中央駅</nobr>
+                <nobr>市区役所公民館</nobr>
+                <nobr>中区役所</nobr>
+                <nobr>西区役所</nobr>
+                <nobr>安佐南区役所</nobr>
+                <nobr>佐伯区役所</nobr>
                 <div className="heading">近隣コンビニ</div>
-                セブンイレブン 広島大原駅前 広島伴東五丁目店 広島新観音橋
+                <nobr>セブンイレブン 広島大原駅前店</nobr>
+                <nobr>広島伴東五丁目店</nobr>
+                <nobr>広島新観音橋店</nobr>
                 <div className="heading">学習塾</div>
-                5-days こども文化科学館 明光義塾 中区役所前教室 明光義塾
-                仁保教室 明光義塾 横川駅前教室 明光義塾 安芸中野東教室
+                <nobr>5-days</nobr>
+                <nobr>こども文化科学館</nobr>
+                <nobr>明光義塾中区役所前教室</nobr>
+                <nobr>明光義塾仁保教室</nobr>
+                <nobr>明光義塾横川駅前教室</nobr>
+                <nobr>明光義塾安芸中野東教室</nobr>
             </div>
         </>
     )

--- a/src/styles/PosterList.css
+++ b/src/styles/PosterList.css
@@ -12,6 +12,6 @@
     font-weight: bold;
 }
 
-.pos-list nobr{
+.pos-list nobr {
     margin: 5px;
 }

--- a/src/styles/PosterList.css
+++ b/src/styles/PosterList.css
@@ -11,3 +11,7 @@
     margin: 50px 0 30px 0;
     font-weight: bold;
 }
+
+.pos-list nobr{
+    margin: 5px;
+}


### PR DESCRIPTION
https://github.com/ichidaisai/2024.ichidaisai.com/issues/167
このissureをもとに、
・ポスター掲示場所の無駄なスペースを消して分かりやすくしました
・近隣コンビニを全て○○店に修正しました
・場所の名前の途中で改行されないようにしました
![スクリーンショット 2024-10-25 211946](https://github.com/user-attachments/assets/dbd39605-ad9c-4b6a-9904-f1f2f8e45d10)