### PR TITLE
イベントページのデザインを統一しました

### DIFF
--- a/src/components/Event.jsx
+++ b/src/components/Event.jsx
@@ -40,10 +40,10 @@ export const Event = () => {
                 </Link>
 
                 <Link
-                    className="event-item"
                     style={{ textDecoration: 'none' }}
                     to="/karimonokyousou"
-                    onclick={returnTop}
+                    className="event-item"
+                    onClick={returnTop}
                 >
                     <div className="event-icon">
                         <img src={karimono_icon} />

--- a/src/pages/Bingo.jsx
+++ b/src/pages/Bingo.jsx
@@ -12,7 +12,6 @@ export const Bingo = () => {
                 <div className="bingo-text">
                     ichidai_sai 毎年恒例ビンゴ大会🎁!!
                     <br />
-                    {/* <br /> */}
                     ビンゴカードは、大学祭実行委員会が行なっている
                     <br />
                     模擬店の利用者と市大祭のグッズを購入された方に配布しております!
@@ -20,16 +19,10 @@ export const Bingo = () => {
                     豪華景品を獲得できるチャンスがビンゴ大会に必要なのは運だけです。
                     <div className="emphasis">運がすべて!!</div>
                     たくさんのご参加お待ちしております♪
-                    {/* <br /> */}
-                    <br />● 日時10/26(土) 17:10~17:40
-                    {/* <br /> */}
-                    <br />● 場所 メインステージ
-                    {/* <br />
-                    <br /> */}
-                    <div className="mailadress">
-                        なにか質問ございましたら
-                        kikaku31th@outlook.jpまでご連絡ください!
-                    </div>
+                    <br />
+                    ● 日時10/26(土) 17:10~17:40
+                    <br />
+                    ● 場所 メインステージ
                 </div>
             </div>
         </>

--- a/src/pages/Karimonokyousou.jsx
+++ b/src/pages/Karimonokyousou.jsx
@@ -17,9 +17,6 @@ export const Karimonokyousou = () => {
                     <br />
                     是非！ご参加ください！
                 </div>
-                <div className="MailAddress">
-                    kikaku31th@outlook.jp まで応募のご連絡お待ちしております！
-                </div>
             </div>
         </>
     )

--- a/src/pages/Kehaigiri.jsx
+++ b/src/pages/Kehaigiri.jsx
@@ -4,7 +4,7 @@ export const Kehaigiri = () => {
     return (
         <>
             <div>
-                <div className="kehaigiri-top">気配切り</div>
+                <div className="kehaigiri-top">気配斬り</div>
                 <div className="icon">
                     <img src={kehaigiri_icon} />
                 </div>

--- a/src/styles/Karimonokyousou.css
+++ b/src/styles/Karimonokyousou.css
@@ -40,8 +40,8 @@
     width: 50%;
     margin: 0 auto;
 }
-.MailAddress {
+/* .MailAddress {
     line-height: 4em;
     text-align: center;
     font-size: 20px;
-}
+} */


### PR DESCRIPTION
借りモノ協走のページとビンゴ大会ページの参加者募集の文言を削除しました。
借りモノ協走のページに遷移するとき一番下に行ってたのを一番上に行くようにしました。

https://github.com/ichidaisai/2024.ichidaisai.com/issues/173#issue-2614257238